### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ ipconfig /flushdns
 ipconfig /registerdns
 ipconfig /release
 ipconfig /renew
+
+
+15 commands you must know
+https://www.makeuseof.com/tag/15-cmd-commands-every-windows-user-know/


### PR DESCRIPTION
Pathping
Ping does a good job of telling you whether two machines can communicate with one another over TCP/IP, but if a ping does fail, you won't receive any information regarding the nature of the failure. This is where the pathping utility comes in.

Pathping is designed for environments in which one or more routers exist between hosts. It sends a series of packets to each router that's in the path to the destination host in an effort to determine whether the router is performing slowly or dropping packets. At its simplest, the syntax for pathping is identical to that of the ping command (although there are some optional switches you can use). The command looks like this:

pathping 192.168.1.1